### PR TITLE
CentOS 7 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ install:
 
   # Create ansible.cfg with correct roles_path
   - printf '[defaults]\nroles_path=../' >ansible.cfg
- 
-  #- ansible-galaxy install indigo-dc.docker
 
 script:
   # Basic role syntax check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+ 
+  #- ansible-galaxy install indigo-dc.docker
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -3,6 +3,9 @@
   fail: msg="The role is designed only for RedHat/CentOS 7.2 or later"
   when: "ansible_distribution not in ('RedHat', 'CentOS') or {{ ansible_distribution_version | version_compare('7.2', '<') }}"
 
+- name: "[EL] Add epel-release repository"
+  yum: name=epel-release state=present
+
 - name: "[EL] Add yum repository"
   get_url: url={{onedata_url}}/yum/centos/7x/onedata.repo dest=/etc/yum.repos.d/onedata.repo
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - indigo-dc.oneclient
+    - ansible-role-oneclient


### PR DESCRIPTION
- add epel repository to install "poco-json" oneclient dependency:
   EPEL x86_64 poco-json-1.6.1-2.el7.x86_64.rpmThe JSON POCO component
- add travis file